### PR TITLE
Add initial version of docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,9 +39,9 @@ jobs:
         run: |
           if [ "$dockerid" != "" ]; then
               docker login -u "$dockerid" -p "$dockerpass"
-              docker pull openloco/openloco:1-bionic
-              docker tag openloco/openloco:1-bionic openloco/openloco:4
-              docker tag openloco/openloco:1-bionic openloco/openloco:latest
+              docker pull openloco/openloco:1-bionic32
+              docker tag openloco/openloco:1-bionic32 openloco/openloco:1
+              docker tag openloco/openloco:1-bionic32 openloco/openloco:latest
               docker push openloco/openloco:1
               docker push openloco/openloco:latest
           else

--- a/1/bionic32/Dockerfile
+++ b/1/bionic32/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        clang \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libopenal-dev:i386 \
+        libpng-dev:i386 \
+        libsdl2-dev:i386 \
+        libsdl2-mixer-dev:i386 \
+        ninja-build \
+        pkg-config:i386 \
+    && rm -rf /var/lib/apt/lists/*

--- a/1/focal32/Dockerfile
+++ b/1/focal32/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        clang \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libopenal-dev:i386 \
+        libpng-dev:i386 \
+        libsdl2-dev:i386 \
+        libsdl2-mixer-dev:i386 \
+        ninja-build \
+        pkg-config:i386 \
+    && rm -rf /var/lib/apt/lists/*

--- a/1/mingw32/Dockerfile
+++ b/1/mingw32/Dockerfile
@@ -1,0 +1,4 @@
+FROM fedora:35
+RUN dnf update -y && \
+  dnf install -y mingw32-SDL2 mingw32-SDL2-static mingw32-SDL2_mixer cmake git ninja-build dnf-plugins-core mingw32-yaml-cpp mingw32-libpng mingw32-openal-soft && \
+  dnf clean all --enablerepo=\*


### PR DESCRIPTION
Includes:
* Fedora 35 for mingw32 (updated from F31 to include openal)
* Ubuntu 18.04 Bionic (current base)
* Ubuntu 20.04 Focal (experimental, see OpenLoco/OpenLoco#1007)