### PR TITLE
Update cmake version in Bionic, Focal to Kitware-provided

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         # Remember if you commit this, newly built images will replace those tags.
         # Prefer incrementing the version to unused one
-        tag: [3-bionic32, 3-mingw32, 3-focal32, 3-jammy32]
+        tag: [4-bionic32, 4-mingw32, 4-focal32, 4-jammy32]
     env:
       dockertag: ${{ matrix.tag }}
     steps:

--- a/4/bionic32/Dockerfile
+++ b/4/bionic32/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:18.04
+
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        ccache \
+        clang \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libopenal-dev:i386 \
+        libpng-dev:i386 \
+        libsdl2-dev:i386 \
+        libsdl2-mixer-dev:i386 \
+        libyaml-cpp-dev:i386 \
+        ninja-build \
+        pkg-config:i386 \
+    && rm -rf /var/lib/apt/lists/*

--- a/4/bionic32/Dockerfile
+++ b/4/bionic32/Dockerfile
@@ -4,12 +4,19 @@ RUN dpkg --add-architecture i386 \
     && apt-get update \
     && apt-get -y upgrade \
     && apt-get install --no-install-recommends -y \
+        gpg wget ca-certificates \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ bionic main" > /etc/apt/sources.list.d/kitware.list \
+    && apt-get update \
+    && rm /usr/share/keyrings/kitware-archive-keyring.gpg \
+    && apt-get install --no-install-recommends -y \
         ccache \
         clang \
         cmake \
         g++-multilib \
         gcc-multilib \
         git \
+        kitware-archive-keyring \
         libopenal-dev:i386 \
         libpng-dev:i386 \
         libsdl2-dev:i386 \

--- a/4/bionic32/Dockerfile
+++ b/4/bionic32/Dockerfile
@@ -17,10 +17,10 @@ RUN dpkg --add-architecture i386 \
         gcc-multilib \
         git \
         kitware-archive-keyring \
+        libgtest-dev \
         libopenal-dev:i386 \
         libpng-dev:i386 \
         libsdl2-dev:i386 \
-        libsdl2-mixer-dev:i386 \
         libyaml-cpp-dev:i386 \
         ninja-build \
         pkg-config:i386 \

--- a/4/focal32/Dockerfile
+++ b/4/focal32/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:20.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        ccache \
+        clang \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libopenal-dev:i386 \
+        libpng-dev:i386 \
+        libsdl2-dev:i386 \
+        libsdl2-mixer-dev:i386 \
+        ninja-build \
+        pkg-config:i386 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/4/focal32/Dockerfile
+++ b/4/focal32/Dockerfile
@@ -5,6 +5,12 @@ RUN dpkg --add-architecture i386 \
     && apt-get update \
     && apt-get -y upgrade \
     && apt-get install --no-install-recommends -y \
+        gpg wget ca-certificates \
+    && wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc | gpg --dearmor - > /usr/share/keyrings/kitware-archive-keyring.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main" > /etc/apt/sources.list.d/kitware.list \
+    && apt-get update \
+    && rm /usr/share/keyrings/kitware-archive-keyring.gpg \
+    && apt-get install --no-install-recommends -y \
         ca-certificates \
         ccache \
         clang \
@@ -12,6 +18,7 @@ RUN dpkg --add-architecture i386 \
         g++-multilib \
         gcc-multilib \
         git \
+        kitware-archive-keyring \
         libopenal-dev:i386 \
         libpng-dev:i386 \
         libsdl2-dev:i386 \

--- a/4/focal32/Dockerfile
+++ b/4/focal32/Dockerfile
@@ -19,10 +19,10 @@ RUN dpkg --add-architecture i386 \
         gcc-multilib \
         git \
         kitware-archive-keyring \
+        libgtest-dev \
         libopenal-dev:i386 \
         libpng-dev:i386 \
         libsdl2-dev:i386 \
-        libsdl2-mixer-dev:i386 \
         ninja-build \
         pkg-config:i386 \
     && update-ca-certificates \

--- a/4/jammy32/Dockerfile
+++ b/4/jammy32/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        ccache \
+        clang \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libopenal-dev:i386 \
+        libpng-dev:i386 \
+        libsdl2-dev:i386 \
+        libsdl2-mixer-dev:i386 \
+        ninja-build \
+        pkg-config:i386 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/4/jammy32/Dockerfile
+++ b/4/jammy32/Dockerfile
@@ -12,10 +12,10 @@ RUN dpkg --add-architecture i386 \
         g++-multilib \
         gcc-multilib \
         git \
+        libgtest-dev \
         libopenal-dev:i386 \
         libpng-dev:i386 \
         libsdl2-dev:i386 \
-        libsdl2-mixer-dev:i386 \
         ninja-build \
         pkg-config:i386 \
     && update-ca-certificates \

--- a/4/mingw32/Dockerfile
+++ b/4/mingw32/Dockerfile
@@ -1,0 +1,4 @@
+FROM fedora:36
+RUN dnf update -y && \
+  dnf install -y mingw32-SDL2 mingw32-SDL2-static mingw32-SDL2_mixer ccache cmake git ninja-build dnf-plugins-core mingw32-yaml-cpp mingw32-libpng mingw32-openal-soft && \
+  dnf clean all --enablerepo=\*

--- a/4/mingw32/Dockerfile
+++ b/4/mingw32/Dockerfile
@@ -1,4 +1,4 @@
 FROM fedora:36
 RUN dnf update -y && \
-  dnf install -y mingw32-SDL2 mingw32-SDL2-static mingw32-SDL2_mixer ccache cmake git ninja-build dnf-plugins-core mingw32-yaml-cpp mingw32-libpng mingw32-openal-soft && \
+  dnf install -y mingw32-SDL2 mingw32-SDL2-static ccache cmake git ninja-build dnf-plugins-core mingw32-yaml-cpp mingw32-libpng mingw32-openal-soft && \
   dnf clean all --enablerepo=\*


### PR DESCRIPTION
This updates cmake version in bionic32, focal32 images to 3.24, currently latest version provided by cmake.

jammy32 has cmake 3.22 in upstream repositories and Kitware offers no updated version for this distro.

mingw32 is based on latest Fedora 36 which has cmake 3.22 as well.