### PR TITLE
Add new Dockerfiles for Ubuntu Jammy, Mantic, and Fedora 38 (MinGW)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         # Remember if you commit this, newly built images will replace those tags.
         # Prefer incrementing the version to unused one
-        tag: [6-bionic32, 6-mingw32, 6-focal32, 6-jammy32]
+        tag: [7-mingw32, 7-jammy32, 7-mantic32]
     env:
       dockertag: ${{ matrix.tag }}
       REGISTRY: ghcr.io

--- a/7/jammy32/Dockerfile
+++ b/7/jammy32/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        ccache \
+        clang \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libgtest-dev:i386 \
+        libopenal-dev:i386 \
+        libpng-dev:i386 \
+        libsdl2-dev:i386 \
+        ninja-build \
+        pkg-config:i386 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/7/mantic32/Dockerfile
+++ b/7/mantic32/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:23.10
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        ccache \
+        clang \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libgtest-dev:i386 \
+        libopenal-dev:i386 \
+        libpng-dev:i386 \
+        libsdl2-dev:i386 \
+        ninja-build \
+        pkg-config:i386 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/7/mingw32/Dockerfile
+++ b/7/mingw32/Dockerfile
@@ -1,0 +1,4 @@
+FROM fedora:38
+RUN dnf update -y && \
+  dnf install -y mingw32-gcc-c++ mingw32-SDL2 mingw32-SDL2-static ccache cmake git ninja-build dnf-plugins-core mingw32-yaml-cpp mingw32-libpng mingw32-openal-soft && \
+  dnf clean all --enablerepo=\*

--- a/7/mingw32/Dockerfile
+++ b/7/mingw32/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:38
+FROM fedora:39
 RUN dnf update -y && \
   dnf install -y mingw32-gcc-c++ mingw32-SDL2 mingw32-SDL2-static ccache cmake git ninja-build dnf-plugins-core mingw32-yaml-cpp mingw32-libpng mingw32-openal-soft && \
   dnf clean all --enablerepo=\*


### PR DESCRIPTION
I've been meaning to add another Ubuntu image to the CI roster since we dropped support for Focal (20.04). Our CI images for MinGW were a bit dated as well, still using Fedora 36.

This PR introduces a new series of Dockerfiles, adding Ubuntu Mantic (23.10) next to Ubuntu Jammy (22.04). In addition, the Fedora image is updated to version 38.

@janisozaur I think some manual action is required to get these available to GitHub Actions. Could you help out with that?