### PR TITLE
Add TBB for gcc and fix unzip on vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
       matrix:
         # Remember if you commit this, newly built images will replace those tags.
         # Prefer incrementing the version to unused one
-        tag: [9-mingw32, 9-jammy32, 9-noble32, 9-noble32vcpkg]
+        tag: [10-mingw32, 10-jammy, 10-jammy32, 10-noble, 10-noble32, 10-noblevcpkg]
     env:
       dockertag: ${{ matrix.tag }}
       REGISTRY: ghcr.io

--- a/10/jammy/Dockerfile
+++ b/10/jammy/Dockerfile
@@ -1,0 +1,22 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        ccache \
+        clang \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libgtest-dev \
+        libtbb-dev \
+        libopenal-dev \
+        libpng-dev \
+        libsdl2-dev \
+        ninja-build \
+        pkg-config \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/10/jammy32/Dockerfile
+++ b/10/jammy32/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        ccache \
+        clang \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libgtest-dev:i386 \
+        libtbb-dev:i386 \
+        libopenal-dev:i386 \
+        libpng-dev:i386 \
+        libsdl2-dev:i386 \
+        ninja-build \
+        pkg-config:i386 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/10/mingw32/Dockerfile
+++ b/10/mingw32/Dockerfile
@@ -1,0 +1,4 @@
+FROM fedora:43
+RUN dnf update -y && \
+  dnf install -y mingw32-gcc-c++ mingw32-SDL2 mingw32-SDL2-static ccache cmake git ninja-build dnf-plugins-core mingw32-yaml-cpp mingw32-libpng mingw32-openal-soft mingw32-libtbb && \
+  dnf clean all --enablerepo=\*

--- a/10/mingw32/Dockerfile
+++ b/10/mingw32/Dockerfile
@@ -1,4 +1,4 @@
-FROM fedora:43
+FROM fedora:41
 RUN dnf update -y && \
-  dnf install -y mingw32-gcc-c++ mingw32-SDL2 mingw32-SDL2-static ccache cmake git ninja-build dnf-plugins-core mingw32-yaml-cpp mingw32-libpng mingw32-openal-soft mingw32-libtbb && \
+  dnf install -y mingw32-gcc-c++ mingw32-SDL2 mingw32-SDL2-static ccache cmake git ninja-build dnf-plugins-core mingw32-yaml-cpp mingw32-libpng mingw32-openal-soft && \
   dnf clean all --enablerepo=\*

--- a/10/noble/Dockerfile
+++ b/10/noble/Dockerfile
@@ -1,0 +1,23 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        ccache \
+        clang \
+        clang-tidy \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libgtest-dev \
+        libtbb-dev \
+        libopenal-dev \
+        libpng-dev \
+        libsdl2-dev \
+        ninja-build \
+        pkg-config \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/10/noble32/Dockerfile
+++ b/10/noble32/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        ca-certificates \
+        ccache \
+        clang \
+        clang-tidy \
+        cmake \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libgtest-dev:i386 \
+        libtbb-dev:i386 \
+        libopenal-dev:i386 \
+        libpng-dev:i386 \
+        libsdl2-dev:i386 \
+        ninja-build \
+        pkg-config:i386 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*

--- a/10/noble32/Dockerfile
+++ b/10/noble32/Dockerfile
@@ -14,7 +14,6 @@ RUN dpkg --add-architecture i386 \
         gcc-multilib \
         git \
         libgtest-dev:i386 \
-        libtbb-dev:i386 \
         libopenal-dev:i386 \
         libpng-dev:i386 \
         libsdl2-dev:i386 \

--- a/10/noblevcpkg/Dockerfile
+++ b/10/noblevcpkg/Dockerfile
@@ -1,0 +1,26 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN dpkg --add-architecture i386 \
+    && apt-get update \
+    && apt-get -y upgrade \
+    && apt-get install --no-install-recommends -y \
+        autoconf \
+        automake \
+        ca-certificates \
+        ccache \
+        clang \
+        clang-tidy \
+        cmake \
+        curl \
+        g++-multilib \
+        gcc-multilib \
+        git \
+        libtool \
+        make \
+        ninja-build \
+        zip \
+        unzip \
+        pkg-config:i386 \
+    && update-ca-certificates \
+    && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This adds tbb as required for libstdc++ and it also adds 64bit images and also fixes vcpkg cache issues by including unzip.